### PR TITLE
Fixes #19

### DIFF
--- a/src/backmatter.sty
+++ b/src/backmatter.sty
@@ -5,7 +5,6 @@
 	\newpage
 	\glsaddall
 	\printglossaries
-	\addcontentsline{toc}{section}{Glossary}
 	\clearpage
 
 	\newpage
@@ -13,20 +12,18 @@
 	\clearpage
 
 	\newcounter{appendixsection}
-	\newcounter{appendixfigurenumber}[appendixsection]
-	\newcounter{appendixtablenumber}[appendixsection]
 
-	\renewcommand{\thefigure}{\Alph{appendixsection}.\arabic{appendixfigurenumber}}
-	\renewcommand{\thetable}{\Alph{appendixsection}.\arabic{appendixtablenumber}}
+	\renewcommand{\thefigure}{
+		\Alph{appendixsection}.\arabic{figure}
+	}
+	\renewcommand{\thetable}{\Alph{appendixsection}.\arabic{table}}
+	
 
 	\renewenvironment{appendix}[1]{
 		\newpage
-
 		\stepcounter{appendixsection}
-		\stepcounter{appendixfigurenumber}
-		\stepcounter{appendixtablenumber}
-
-
+		\setcounter{figure}{0}
+		\setcounter{table}{0}
 		\addcontentsline{toc}{section}{Appendix \Alph{appendixsection}: ##1}
 		\section*{Appendix \Alph{appendixsection}: ##1}
 	}

--- a/src/clean_directory.sh
+++ b/src/clean_directory.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # Clean up the source directory
+filename=example
 
 rm ${filename}.aux
 rm ${filename}.bbl
@@ -12,4 +13,7 @@ rm ${filename}.lot
 rm ${filename}.run.xml
 rm ${filename}.toc
 rm ${filename}.xdy
+rm ${filename}.glg
+rm ${filename}.gls
+rm ${filename}.log
 rm ./texput.log

--- a/src/example.tex
+++ b/src/example.tex
@@ -326,6 +326,12 @@ Here's a reference to table \ref{tbl:exampletable}
 		\caption{It's back!}
 	\end{figure}
 
+	\begin{figure}[!ht]
+		\centering
+		\includegraphics[width=5cm]{./stock-image.jpg}
+		\caption{Testing Number}
+	\end{figure}
+
 \end{appendix}
 
 \begin{appendix}{A Table in An Appendix}
@@ -343,6 +349,15 @@ Here's a reference to table \ref{tbl:exampletable}
 		
 		\caption{A Table in an Appendix, displaying the correct numbering}
         \end{table}
+
+	\begin{table}
+		\centering
+		\begin{tabular}{|c|c|c|} \hline
+			\textbf{Data} & \textbf{Integer} & \textbf{String} \\ \hline
+			Foo & 1 & "bar" \\ \hline
+		\end{tabular}
+		\caption{Another table to test numbering}
+	\end{table}
 
 \end{appendix}
 


### PR DESCRIPTION
Fixes #19 by resetting the figure and table counter in each appendix, instead of using a custom figure and table number.

Also fixes a double-entry bug where the Glossary section was added twice to the contents.
