### PR TITLE
Fixes #21: Removes trailing stop

### DIFF
--- a/src/workreport.cls
+++ b/src/workreport.cls
@@ -37,7 +37,7 @@
 
 
 % Creates and manages the glossary section of the work term report.
-\RequirePackage[toc, xindy, nonumberlist]{glossaries}
+\RequirePackage[toc, xindy, nonumberlist, nopostdot]{glossaries}
 
 % Manages references made in the work term report, using references stored in a
 % .bib file


### PR DESCRIPTION
This PR fixes issue #21, by adding a `nopostdot` option to the glossaries package definition.
